### PR TITLE
Fix typo in handler-ponymailer.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased][unreleased]
 
+### Fixed
+- fix typo in handler-ponymailer.rb
+
 ## 0.0.1 - 2015-06-02
 
 ### Added

--- a/bin/handler-ponymailer.rb
+++ b/bin/handler-ponymailer.rb
@@ -44,13 +44,13 @@ class PonyMailer < Sensu::Handler
       sender: settings['ponymailer']['from']
     }
     mail_options.merge!(via_options: {
-                           address: settings['ponymailer']['hostname'],
-                           port: settings['ponymailer']['port'],
-                           enable_starttls_auto: settings['ponymailer']['tls'],
-                           user_name: settings['ponymailer']['username'],
-                           password: settings['ponymailer']['password'],
-                           authentication: :plain
-                         }) if settings['ponymailer']['authenticate']
+                          address: settings['ponymailer']['hostname'],
+                          port: settings['ponymailer']['port'],
+                          enable_starttls_auto: settings['ponymailer']['tls'],
+                          user_name: settings['ponymailer']['username'],
+                          password: settings['ponymailer']['password'],
+                          authentication: :plain
+                        }) if settings['ponymailer']['authenticate']
 
     mail_options[:body] = %(Sensu has detected a failed check. Event analysis follows:
 

--- a/bin/handler-ponymailer.rb
+++ b/bin/handler-ponymailer.rb
@@ -43,7 +43,7 @@ class PonyMailer < Sensu::Handler
       charset: 'utf-8',
       sender: settings['ponymailer']['from']
     }
-    mail_options.merg e!(via_options: {
+    mail_options.merge!(via_options: {
                            address: settings['ponymailer']['hostname'],
                            port: settings['ponymailer']['port'],
                            enable_starttls_auto: settings['ponymailer']['tls'],


### PR DESCRIPTION
Causing error bin/handler-ponymailer.rb:46:in `handle': undefined method`e!' for #PonyMailer:0x00000002353ae8 (NoMethodError)
