### PR TITLE
fix undefined method `arguments'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - fix typo in handler-ponymailer.rb
+- fix undefined method `arguments'
 
 ## 0.0.1 - 2015-06-02
 

--- a/bin/handler-ponymailer.rb
+++ b/bin/handler-ponymailer.rb
@@ -34,7 +34,6 @@ class PonyMailer < Sensu::Handler
       subject: "Sensu Monitoring Alert: #{action_to_string} :: #{short_name}",
       from: "#{settings['ponymailer']['fromname']} <#{settings['ponymailer']['from']}>",
       via: :smtp,
-      arguments: '',
       via_options: {
         address: settings['ponymailer']['hostname'],
         port: settings['ponymailer']['port'],


### PR DESCRIPTION
undefined method `arguments' for #Mail::Message:0x0000000268fc70 (NoMethodError)
Can't find any reference as to why arguments is there, certanly not supported in any recent versions of ponymailer or mail.
